### PR TITLE
Additional submission validations

### DIFF
--- a/file-uploader.js
+++ b/file-uploader.js
@@ -13,6 +13,24 @@ import { fileUploaderUtil } from './file-uploader-util';
  * @param {Function} callback
  *
  * @return {Promise}
+ * 
+ * Note: Error Format
+ * {
+ * "error": {
+ *   "type": "ValidationError",
+ *   "message": "invalid submission object",
+ *   "details": [
+ *     {
+ *       "message": "field 'submissionMethod' in Submission.measurementSets[0] is invalid: cmsWebInterface is not allowed via file upload",
+ *       "path": "$.measurementSets[0].submissionMethod"
+ *     },
+ *     {
+ *       "message": "field 'submissionMethod' in Submission.measurementSets[1] is invalid: cmsWebInterface is not allowed via file upload",
+ *       "path": "$.measurementSets[1].submissionMethod"
+ *     }
+ *   ]
+ * }
+ *}
  */
 export function fileUploader(submissionBody, submissionFormat, JWT, baseSubmissionURL, callback) {
   let validatedSubmission;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/qpp-file-upload-api-client",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Added validation to disallow cmsWebInterface during file upload per issue #20.  Also, enhanced error handling so that it returns a proper rejected promise instead of a nested Error object so that our manually errors match the format of our API errors.