### PR TITLE
Normalized error payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,65 @@ A set of functions to call the QPP Submissions API in common manner, such as for
 To use, simply `npm install qpp-file-upload-api-client`
 
 ## fileUploader()
+
 The `fileUploader()` function exported by this module uses the following set of requests on the Submissions API:
 
 1. Parse the submission object and call POST /submissions/validate to ensure that it's a valid submission
 1. Call GET /submissions with query parameters to find any matching submission and measurementSets
 1. Given the result of GET /submissions, determine whether to PUT or POST measurementSets from the file being uploaded
 
-Arguments
----------
+## Arguments
 
-1. `submissionBody`: A string containing the QPP JSON or QPP XML Submission body. See the [Submissions API Developer Documentation](cmsgov.github.io/qpp-submissions-docs) for more information on schemas, but you can use this example payload to use with the `fileUploader()` function: [example payload](https://gist.github.com/samskeller/0eeb89ead1ddb189236593e2a9aa1034)
-1. `submissionFormat`: A string specifying the format -- only "JSON" and "XML" are supported
-1. `JWT`: A string with the user's JSON Web Token (JWT)
-1. `baseSubmissionURL`: A string with the base URL to be used to specify the Submissions API -- for the production instance of the Submissions API, for example, you'd use `https://qpp.cms.gov/api/submissions`
-1. `callback`: A callback function to be called when the `fileUploader()` function is finished. Should accept an array of Error objects as the first argument, for the list of Errors that were thrown during the function call, and an array of created measurementSets (Objects) as the second argument
+1.`submissionBody`: A string containing the QPP JSON or QPP XML Submission body. See the [Submissions API Developer Documentation](cmsgov.github.io/qpp-submissions-docs) for more information on schemas, but you can use this example payload to use with the `fileUploader()` function: [example payload](https://gist.github.com/samskeller/0eeb89ead1ddb189236593e2a9aa1034)
+
+2.`submissionFormat`: A string specifying the format -- only "JSON" and "XML" are supported
+
+3.`JWT`: A string with the user's JSON Web Token (JWT)
+
+4.`baseSubmissionURL`: A string with the base URL to be used to specify the Submissions API -- for the production instance of the Submissions API, for example, you'd use `https://qpp.cms.gov/api/submissions`
+
+5.`callback: (errors: ResponseError[], measurementSets: MeasurementSet[]): void`: A callback function to be called when the `fileUploader()` function is finished. Should accept an array of Error objects as the first argument, for the list of ResponseError that were thrown during the function call, and an array of created measurementSets (Objects) as the second argument
+
+### Callback Response Example
+
+```javascript
+// ResponseError[]
+[
+    {
+        type: string (optional),
+        message: string (optional),
+        details: (optional) [
+            {
+                message: string,
+                path: string
+            }
+        ]
+    }
+]
+
+// Measurement Set[]
+{
+    "id": "060eb4b1-1a93-467e-b3eb-0b8518ed4d49",
+    "submissionId": "060eb4b1-1a93-467e-b3eb-0b8518ed4d49",
+    "category": "ia",
+    "submissionMethod": "cmsWebInterface",
+    "submitterId": "060eb4b1-1a93-467e-b3eb-0b8518ed4d49",
+    "submitterType": "organization",
+    "performanceStart": "2017-01-01",
+    "performanceEnd": "2017-06-01",
+    "measurements": [
+    {
+        "measureId": "IA_EPA_4",
+        "value": true,
+        "id": "b24aa2c2-f1ab-4d28-a7a4-882d93e5a31d",
+        "measurementSetId": "d2acc2af-8382-402e-aa97-0fd118451b22"
+    }
+    ]
+}
+```
 
 ## Testing
+
 To run the automated tests for this module, simply run:
 
 ```bash

--- a/file-uploader-util.js
+++ b/file-uploader-util.js
@@ -59,7 +59,7 @@ export function validateSubmission(submission, submissionFormat, baseOptions) {
 
     return validatedSubmission;
   }).catch(err => {
-    return Promise.reject((err && err.response && err.response.data) || err);
+    return Promise.reject((err && err.response && err.response.data && err.response.data.error) || err);
   });
 };
 
@@ -120,6 +120,8 @@ export function getExistingSubmission(submission, baseOptions) {
       };
 
       return matchingExistingSubmissions[0];
+    }).catch(err => {
+      return Promise.reject((err && err.response && err.response.data && err.response.data.error) || err);
     });
 };
 
@@ -139,6 +141,8 @@ export function putMeasurementSet(measurementSet, baseOptions, measurementSetId)
   }).then((body) => {
     // Assuming a 200 response here
     return body.data.data.measurementSet;
+  }).catch(err => {
+    return Promise.reject((err && err.response && err.response.data && err.response.data.error) || err);
   });
 };
 
@@ -157,6 +161,8 @@ export function postMeasurementSet(measurementSet, baseOptions) {
   }).then((body) => {
     // Assuming a 201 response here
     return body.data.data.measurementSet;
+  }).catch(err => {
+    return Promise.reject((err && err.response && err.response.data && err.response.data.error) || err);
   });
 };
 
@@ -200,6 +206,7 @@ export function submitMeasurementSets(existingSubmission, submission, baseOption
       return existingMeasurementSet.submissionMethod === measurementSet.submissionMethod &&
         existingMeasurementSet.category === measurementSet.category;
     });
+
     if (matchingMeasurementSets.length > 0) {
       // Do a PUT
       const matchingMeasurementSetId = matchingMeasurementSets[0].id;

--- a/file-uploader.js
+++ b/file-uploader.js
@@ -84,13 +84,18 @@ export function fileUploader(submissionBody, submissionFormat, JWT, baseSubmissi
 
       // Transform rejected promises into Errors so they are caught and don't short-circuit
       // the others
-      const caughtPromises = postAndPutPromises.map(promise => promise.catch(Error));
+      const caughtPromises = postAndPutPromises.map(promise => promise.catch(err => {
+        return {
+          error: err
+        };
+      }));
+
       return Promise.all(caughtPromises);
     }).then((postAndPutOutputs) => {
       // Aggregate the errors and created measurementSets
       postAndPutOutputs.forEach((postOrPutOutput) => {
-        if (postOrPutOutput instanceof Error) {
-          errs.push(postOrPutOutput);
+        if (postOrPutOutput && postOrPutOutput.error) {
+          errs.push(postOrPutOutput.error);
         } else {
           createdMeasurementSets.push(postOrPutOutput);
         };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/qpp-file-upload-api-client",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "An npm package to send the necessary requests to the Submissions API to execute the functionality required by a file upload client",
   "main": "./dist/index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Completes #16 

This PR normalizes the error payload to always return the following format:

```
[
    {
        type: string (optional),
        message: string (optional),
        details: (optional) [
            {
                message: string,
                path: string
            }
        ]
    }
]
```