### PR TITLE
QPPSF-2382: virtual group updates

### DIFF
--- a/file-uploader-util.js
+++ b/file-uploader-util.js
@@ -99,9 +99,11 @@ export function getExistingSubmission(submission, baseOptions) {
     return `${encodeURIComponent(key)}=${encodeURIComponent(queryParams[key])}`;
   }).join('&');
 
-  const headers = Object.assign({}, baseOptions.headers, {
-    'qpp-taxpayer-identification-number': submission.taxpayerIdentificationNumber
-  });
+  const headers = Object.assign({}, baseOptions.headers);
+  
+  if (submission.taxpayerIdentificationNumber) {
+    headers['qpp-taxpayer-identification-number'] = submission.taxpayerIdentificationNumber;
+  }
 
   return axios.get(baseOptions.url + '/submissions?' + queryParamString, {
     headers: headers
@@ -205,7 +207,7 @@ export function submitMeasurementSets(existingSubmission, submission, baseOption
         programName: submission.programName,
         entityType: submission.entityType,
         entityId: submission.entityId || null,
-        taxpayerIdentificationNumber: submission.taxpayerIdentificationNumber,
+        taxpayerIdentificationNumber: submission.taxpayerIdentificationNumber || null,
         nationalProviderIdentifier: submission.nationalProviderIdentifier || null,
         performanceYear: submission.performanceYear
       }});

--- a/file-uploader-util.js
+++ b/file-uploader-util.js
@@ -94,6 +94,10 @@ export function getExistingSubmission(submission, baseOptions) {
     queryParams.performanceYear = submission.performanceYear;
   }
 
+  if (submission.entityType) {
+    queryParams.entityType = submission.entityType;
+  }
+
   // Make a string of URL-encoded query parameters
   const queryParamString = Object.keys(queryParams).map((key) => {
     return `${encodeURIComponent(key)}=${encodeURIComponent(queryParams[key])}`;
@@ -109,25 +113,20 @@ export function getExistingSubmission(submission, baseOptions) {
     headers: headers
   }).then((body) => {
     const jsonBody = body.data;
-    const existingSubmissions = jsonBody.data.submissions;
+    const totalItems = jsonBody.data.totalItems;
+    const submissions = jsonBody.data.submissions;
 
-    // Look for a submission with the same entityType -- need to do this here because
-    // we can't filter on entityType in our API call to GET /submissions
-    const matchingExistingSubmissions = existingSubmissions.filter((existingSubmission) => {
-      return existingSubmission.entityType === submission.entityType;
-    });
-
-    if (matchingExistingSubmissions.length > 1) {
+    if (totalItems > 1) {
       return Promise.reject(
         createErrorResponse('ValidationError', 'Could not determine which existing Submission matches request')
       );
     }
 
-    if (matchingExistingSubmissions.length === 0) {
+    if (totalItems === 0) {
       return;
     }
 
-    return matchingExistingSubmissions[0];
+    return submissions[0];
   }).catch(err => {
     return Promise.reject((err && err.response && err.response.data && err.response.data.error) || err);
   });
@@ -189,6 +188,7 @@ export function postMeasurementSet(measurementSet, baseOptions) {
  */
 export function submitMeasurementSets(existingSubmission, submission, baseOptions, requestHeaders) {
   const encodedToken = requestHeaders && requestHeaders.Authorization && requestHeaders.Authorization.split(' ')[1];
+  const orgId = requestHeaders && requestHeaders['organization-id'];
   const token = jwtDecode.default(encodedToken);
   const organizations = (token && token.data && token.data.organizations) || [];
   const isRegistryUser = organizations.some(org => org.orgType === 'registry' || org.orgType === 'qcdr');
@@ -214,12 +214,11 @@ export function submitMeasurementSets(existingSubmission, submission, baseOption
     }
 
     // Look for existing measurementSets with the same category + submissionMethod + cpcPlus practiceId
-
     const matchingMeasurementSets = existingMeasurementSets.filter((existingMeasurementSet) => {
       return (
         (
           (!isRegistryUser && existingMeasurementSet.submitterId === 'securityOfficial') ||
-            (isRegistryUser && organizations.some(org => org.id === existingMeasurementSet.submitterId))
+          (isRegistryUser && orgId === existingMeasurementSet.submitterId)
         ) &&
             (existingMeasurementSet.submissionMethod === measurementSet.submissionMethod) &&
             (existingMeasurementSet.category === measurementSet.category) &&

--- a/file-uploader.js
+++ b/file-uploader.js
@@ -63,7 +63,7 @@ export function fileUploader(submissionBody, submissionFormat, requestHeaders, b
           programName: validatedSubmission.programName,
           entityType: validatedSubmission.entityType,
           entityId: validatedSubmission.entityId || null,
-          taxpayerIdentificationNumber: validatedSubmission.taxpayerIdentificationNumber,
+          taxpayerIdentificationNumber: validatedSubmission.taxpayerIdentificationNumber || null,
           nationalProviderIdentifier: validatedSubmission.nationalProviderIdentifier || null,
           performanceYear: validatedSubmission.performanceYear
         }});

--- a/package-lock.json
+++ b/package-lock.json
@@ -2660,7 +2660,9 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "node-pre-gyp": {
           "version": "0.6.36",

--- a/test/file-uploader-util.spec.js
+++ b/test/file-uploader-util.spec.js
@@ -269,7 +269,7 @@ describe('fileUploaderUtils', () => {
       return getExistingSubmission(validSubmission, baseOptions)
         .then((returnedSubmission) => {
           sinon.assert.calledOnce(axiosGetStub);
-          assert.strictEqual(axiosGetStub.firstCall.args[0], `/submissions?nationalProviderIdentifier=${validSubmission.nationalProviderIdentifier}&performanceYear=${validSubmission.performanceYear}`);
+          assert.strictEqual(axiosGetStub.firstCall.args[0], `/submissions?nationalProviderIdentifier=${validSubmission.nationalProviderIdentifier}&performanceYear=${validSubmission.performanceYear}&entityType=${validSubmission.entityType}`);
 
           assert.exists(returnedSubmission);
           assert.strictEqual(returnedSubmission.id, '001');
@@ -337,7 +337,7 @@ describe('fileUploaderUtils', () => {
       return getExistingSubmission(validSubmission, baseOptions)
         .then((returnedSubmission) => {
           sinon.assert.calledOnce(axiosGetStub);
-          assert.strictEqual(axiosGetStub.firstCall.args[0], `/submissions?nationalProviderIdentifier=${validSubmission.nationalProviderIdentifier}&performanceYear=${validSubmission.performanceYear}`);
+          assert.strictEqual(axiosGetStub.firstCall.args[0], `/submissions?nationalProviderIdentifier=${validSubmission.nationalProviderIdentifier}&performanceYear=${validSubmission.performanceYear}&entityType=${validSubmission.entityType}`);
 
           assert.exists(returnedSubmission);
           assert.strictEqual(returnedSubmission.entityId, '123456');


### PR DESCRIPTION
This PR updates the file upload client to:
1.  Work with virtual groups
2.  filter GET /submissions by entityType
3.  Use the organization id in the header as the matcher for measurement sets for registry users.