### PR TITLE
Chore/update release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The **develop** branch is considered to be the main branch where the source code
     ```
 
 3. Open a PR into **master** from the release branch.
-4. Merge **master** PR once all checks have passed, get 1 approval from a reviewer as well.
+4. Merge **master** PR once all checks have passed, get 1 approval from a reviewer as well. **Make sure NOT TO SQUASH when merging to preserve commit history**
 5. Draft a new release [GitHub Release Page](https://github.com/CMSgov/qpp-file-upload-api-client/releases).
    1. Click Draft a new release
    2. Select the target as the release branch you created `release/x.x.x`
@@ -158,7 +158,7 @@ The **develop** branch is considered to be the main branch where the source code
    1. Open up the draft release, and verify it is not marked as a pre release
    2. select **publish release** to publish the release
       - The npm-publish action should kick off and publish a new version to [NPM](https://www.npmjs.com/package/qpp-file-upload-api-client?activeTab=versions).
-7. Open a PR into **develop** from **master** to backfill any commits on the release branch that are not in develop.
+7. Open a PR into **develop** from **master** to backfill any commits on the release branch that are not in develop. **Make sure NOT TO SQUASH when merging to preserve commit history**
 
 ### Release Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -145,19 +145,20 @@ The **develop** branch is considered to be the main branch where the source code
     git push
     ```
 
-3. Open PRs into both **develop** and **master** from the release branch.
-4. Merge both **develop** and **master** PR's and **delete the release branch**.
+3. Open a PR into **master** from the release branch.
+4. Merge **master** PR once all checks have passed, get 1 approval from a reviewer as well.
 5. Draft a new release [GitHub Release Page](https://github.com/CMSgov/qpp-file-upload-api-client/releases).
    1. Click Draft a new release
-   2. Select the target as the release branch you created `release/x.x.x-beta.0`
-   3. Create a new tag for the beta version `vx.x.x-beta.0`
-   4. Edit the release title to be the version `vx.x.x-beta.0`
-   5. Edit the description to include the version `vx.x.x-beta.0` and whatever notes you find relevant
+   2. Select the target as the release branch you created `release/x.x.x`
+   3. Create a new tag for the beta version `vx.x.x`
+   4. Edit the release title to be the version `vx.x.x`
+   5. Edit the description to include the version `vx.x.x` and whatever notes you find relevant
    6. Save draft, or if you are ready to publish now click Publish release and skip the next step
 6. When you're ready to publish the beta version to NPM, publish the draft release from the previous step
    1. Open up the draft release, and verify it is not marked as a pre release
    2. select **publish release** to publish the release
       - The npm-publish action should kick off and publish a new version to [NPM](https://www.npmjs.com/package/qpp-file-upload-api-client?activeTab=versions).
+7. Open a PR into **develop** from **master** to backfill any commits on the release branch that are not in develop.
 
 ### Release Troubleshooting
 


### PR DESCRIPTION
Update release docs to follow the same release branching flow as the other repos our team owns.