### PR TITLE
fix/QPPSF-10733: Update actions to thev3

### DIFF
--- a/.github/workflows/git-leaks.yml
+++ b/.github/workflows/git-leaks.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: gitleaks-action
-      uses: gitleaks/gitleaks-action@v2
+      uses: gitleaks/gitleaks-action@v1.6

--- a/.github/workflows/git-leaks.yml
+++ b/.github/workflows/git-leaks.yml
@@ -8,6 +8,6 @@ jobs:
     name: Scan for commited secrets
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: gitleaks-action
-      uses: gitleaks/gitleaks-action@v1.6.0
+      uses: gitleaks/gitleaks-action@v2

--- a/.github/workflows/git-leaks.yml
+++ b/.github/workflows/git-leaks.yml
@@ -5,9 +5,9 @@ on:
 
 jobs:
   gitleaks:
-    name: Scan for committed secrets
+    name: Scan for commited secrets
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: gitleaks-action
       uses: gitleaks/gitleaks-action@v1.6.0

--- a/.github/workflows/git-leaks.yml
+++ b/.github/workflows/git-leaks.yml
@@ -5,9 +5,9 @@ on:
 
 jobs:
   gitleaks:
-    name: Scan for commited secrets
+    name: Scan for committed secrets
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: gitleaks-action
-      uses: gitleaks/gitleaks-action@v1.6
+      uses: gitleaks/gitleaks-action@v1.6.0

--- a/.github/workflows/git-leaks.yml
+++ b/.github/workflows/git-leaks.yml
@@ -8,6 +8,6 @@ jobs:
     name: Scan for committed secrets
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     - name: gitleaks-action
       uses: gitleaks/gitleaks-action@v1.6.0

--- a/.github/workflows/git-leaks.yml
+++ b/.github/workflows/git-leaks.yml
@@ -8,6 +8,6 @@ jobs:
     name: Scan for committed secrets
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
     - name: gitleaks-action
       uses: gitleaks/gitleaks-action@v1.6.0


### PR DESCRIPTION
* Verified with Peter that v2 does not have any signficant changes that we would need to update our github actions job to. v2 requires a license and none of the features are security related.
* We are keeping v1.6 and will be closing out https://github.com/CMSgov/qpp-file-upload-api-client/issues/170. 
* Updated actions to latest version v3 instead in this PR.